### PR TITLE
Allowing the client to select their display type without hacking the library's internal "settings.h" file

### DIFF
--- a/_settings/SSD_13XX_settings.h
+++ b/_settings/SSD_13XX_settings.h
@@ -28,10 +28,17 @@ You must select just ONE and comment the others.
 Default: #include "../_display/SSD_1331_96x64.h"
 (uncomment just one below...)
 ----------------------------------------------------------------------------------*/
+#if defined SSD_1331_96x64_DISPLAY
 	#include "../_display/SSD_1331_96x64.h"
-	//#include "../_display/SSD_1331_REDPCB.h"
-	//#include "../_display/SSD_1332_96x64.h"
-	//#include "../_display/SSD_1351_128x128.h"
+#elif defined SSD_1331_REDPCB_DISPLAY
+	#include "../_display/SSD_1331_REDPCB.h"
+#elif defined SSD_1332_96x64_DISPLAY
+	#include "../_display/SSD_1332_96x64.h"
+#elif defined SSD_1351_128x128_DISPLAY
+	#include "../_display/SSD_1351_128x128.h"
+#else
+	#error You need to specify your display by defining one of the following macros: SSD_1331_96x64_DISPLAY, SSD_1331_REDPCB_DISPLAY, SSD_1332_96x64_DISPLAY, SSD_1351_128x128_DISPLAY
+#endif
 /*--------------------------------------------------------------------------------
 - Size Reducing (decrease slight performances) -
 Ignored for Teensy 3.x, DUE

--- a/_settings/SSD_13XX_settings.h
+++ b/_settings/SSD_13XX_settings.h
@@ -37,7 +37,8 @@ Default: #include "../_display/SSD_1331_96x64.h"
 #elif defined SSD_1351_128x128_DISPLAY
 	#include "../_display/SSD_1351_128x128.h"
 #else
-	#error You need to specify your display by defining one of the following macros: SSD_1331_96x64_DISPLAY, SSD_1331_REDPCB_DISPLAY, SSD_1332_96x64_DISPLAY, SSD_1351_128x128_DISPLAY
+	#include "../_display/SSD_1331_96x64.h"
+	#pragma message("You need to specify your display by defining one of the following macros: SSD_1331_96x64_DISPLAY, SSD_1331_REDPCB_DISPLAY, SSD_1332_96x64_DISPLAY, SSD_1351_128x128_DISPLAY")
 #endif
 /*--------------------------------------------------------------------------------
 - Size Reducing (decrease slight performances) -


### PR DESCRIPTION
Having to select your display by editing the library files is inconvenient in more ways than one. I have introduced one minor change into `SSD_13XX_settings.h` so that you now can choose your display by putting `#define DISPLAY_TYPE_MACRO`  prior to including SSD_13XX.

The original behavior is preserved, defining a macro is optional.